### PR TITLE
Make the greedy algorithm used by smartProduct a little smarter. When…

### DIFF
--- a/lib/Numeric/LinearAlgebra/Array/Internal.hs
+++ b/lib/Numeric/LinearAlgebra/Array/Internal.hs
@@ -501,7 +501,7 @@ smartProduct ts = r where
     g a b = case analyzeProduct a b of
               Nothing -> error $ "inconsistent dimensions in smartProduct: "++(show $ dims a)++" and "++(show $ dims b)
               Just (_,c) -> c
-    pairs = [ ((i,j), g a b) | (i,a) <- init xs, (j,b) <- drop (i+1) xs ]
+    pairs = [ ((i,j), g a b - product (sizes a) - product (sizes b)) | (i,a) <- init xs, (j,b) <- drop (i+1) xs ]
     (p,q) = fst $ minimumBy (compare `on` snd) pairs
     r = smartProduct (ts!!p * ts!!q : (dropElemPos p . dropElemPos q) ts)
 


### PR DESCRIPTION
Make the greedy algorithm used by smartProduct a little smarter. When choosing which (a,b) pair of tensors to contract next, instead of minimizing the size of a*b, we instead minimize size (a*b) - size a - size b, which minimizes the total size of all remaining tensors to contract. Before this change, large tensors may be ignored by the algorithm until many small tensors have already been contracted. This change even improves the performance of matrix contractions. For example, a*b*c will be faster when the matrix sizes are: `a~1000x10, b~10x1, c~1x10`. Before, (b,c) were contracted first. But now (a, b) are contracted first, which is ~10x faster.