### PR TITLE
make tensor transpose faster

### DIFF
--- a/hTensor.cabal
+++ b/hTensor.cabal
@@ -35,7 +35,7 @@ extra-source-files:
 
 library
 
-    Build-Depends:      base<5, hmatrix>=0.17, containers, random
+    Build-Depends:      base<5, hmatrix>=0.18, containers, random
 
     hs-source-dirs:     lib
     Exposed-modules:    Numeric.LinearAlgebra.Array.Util


### PR DESCRIPTION
As explained in https://github.com/albertoruiz/hTensor/issues/4 this branch makes tridx faster by using a new `reorderVector` function from the hmatrix library.
Once the hmatrix library gets a version bump, the hmatrix version in the hTensor cabal file should also be bumped.