### PR TITLE
fix conjugation typo

### DIFF
--- a/lib/Numeric/LinearAlgebra/Array/Internal.hs
+++ b/lib/Numeric/LinearAlgebra/Array/Internal.hs
@@ -67,7 +67,7 @@ import Data.Function(on)
 import Debug.Trace
 
 dim x = LA.size x
-trans x = LA.tr x
+trans x = LA.tr' x
 
 ident n = diagRect 0 (konst 1 n) n n
 


### PR DESCRIPTION
`analyzeProduct` and `firstIdx` use the `trans` function to transpose a matrix. Thus `LA.tr'` should be used instead of `LA.tr` since a complex conjugation should not be performed.