### PR TITLE
Various changes for GHC9 series

### DIFF
--- a/hTensor.cabal
+++ b/hTensor.cabal
@@ -1,5 +1,5 @@
 Name:               hTensor
-Version:            0.9.1
+Version:            0.9.2
 License:            BSD3
 License-file:       LICENSE
 Author:             Alberto Ruiz
@@ -59,4 +59,3 @@ library
 source-repository head
     type:     git
     location: https://github.com/AlbertoRuiz/hTensor
-

--- a/lib/Numeric/LinearAlgebra/Array.hs
+++ b/lib/Numeric/LinearAlgebra/Array.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableInstances, FlexibleContexts #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Numeric.LinearAlgebra.Array

--- a/lib/Numeric/LinearAlgebra/Array/Decomposition.hs
+++ b/lib/Numeric/LinearAlgebra/Array/Decomposition.hs
@@ -20,6 +20,7 @@ module Numeric.LinearAlgebra.Array.Decomposition (
     ALSParam(..), defaultParameters
 ) where
 
+import Prelude hiding ((<>))
 import Numeric.LinearAlgebra.Array
 import Numeric.LinearAlgebra.Array.Internal(seqIdx,namesR,sizesR,renameRaw)
 import Numeric.LinearAlgebra.Array.Util

--- a/lib/Numeric/LinearAlgebra/Array/Internal.hs
+++ b/lib/Numeric/LinearAlgebra/Array/Internal.hs
@@ -12,7 +12,7 @@
 --
 -- The arrays provided by this library are immutable, built on top of hmatrix
 -- structures.
--- Operations work on complete structures (indexless), and dimensions have \"names\", 
+-- Operations work on complete structures (indexless), and dimensions have \"names\",
 -- in order to select the desired contractions in tensor computations.
 --
 -- This module contains auxiliary functions not required by the end user.
@@ -58,6 +58,7 @@ module Numeric.LinearAlgebra.Array.Internal (
     debug
 ) where
 
+import Prelude hiding((<>))
 import qualified Numeric.LinearAlgebra.Devel as LA
 import qualified Numeric.LinearAlgebra as LA
 import Numeric.LinearAlgebra hiding (size,scalar,ident)
@@ -245,7 +246,7 @@ matrixatorFree t nr = (reshape s (coords q), nc) where
     s = product (map (flip size t) nc)
 
 -- | Create a list of the substructures at the given level.
-parts :: (Coord t) 
+parts :: (Coord t)
       => NArray i t
       -> Name        -- ^ index to expand
       -> [NArray i t]
@@ -366,13 +367,13 @@ basisOf t = map (dims t `mkNArray`) $ toRows (ident . dim . coords $ t)
 -- --    cmap f (A d v) = A d (cmap f v)
 --     conj (A d v) = A d (conj v)
 --     complex' (A d v) = A d (complex' v) -- mapArray without constraints
--- 
+--
 --     toComplex (A d1 r, A d2 c)  -- zipArray without constraints
 --         | d1==d2 = A d1 (toComplex (r,c))
 --         | otherwise = error "toComplex on arrays with different structure"
--- 
+--
 --     fromComplex (A d v) = (A d *** A d) (fromComplex v)
--- 
+--
 --     single' (A d v) = A d (single' v)
 --     double' (A d v) = A d (double' v)
 
@@ -559,4 +560,3 @@ smartProduct = contractTensors . foldl' (flip addTensor) dat0  where
 -- | sequence of n indices with given prefix
 seqIdx :: Int -> String -> [Name]
 seqIdx n prefix = [prefix ++ show k | k <- [1 .. n] ]
-

--- a/lib/Numeric/LinearAlgebra/Array/Simple.hs
+++ b/lib/Numeric/LinearAlgebra/Array/Simple.hs
@@ -41,7 +41,7 @@ instance Compat None where
 type Array t = NArray None t
 
 instance (Coord t) => Show (Array t) where
-    show t | null (dims t) = "scalar "++ show (coords t !0)
+    show t | null (dims t) = "scalar "++ show (coords t ! 0)
            | order t == 1 = "index " ++ show n ++" " ++ (show . toList . coords $ t)
            | otherwise = "index "++ show n ++ " [" ++ ps ++ "]"
       where n = head (namesR t)
@@ -56,5 +56,3 @@ listArray :: (Coord t)
     -> Array t
 listArray ds cs = mkNArray dms (product ds |> (cs ++ repeat 0))
     where dms = zipWith3 Idx (repeat None) ds (map show [1::Int ..])
-
-


### PR DESCRIPTION
Small changes so the library compiles with ghc9.6.3. 
Bumped version 1 in last digit.
Mostly hiding Prelude.(<>) and one instance of adding a space in "!0" and one instance of adding "FlexibleContexts"
FYI: I get a few warnings about non-exhaustive pattern matches. Should this concern me?